### PR TITLE
Change output excel filename path

### DIFF
--- a/evaluate/duplicates.go
+++ b/evaluate/duplicates.go
@@ -1,5 +1,9 @@
 package evaluate
 
+import (
+	"github.com/teapod89/puffer/util/list"
+)
+
 func Duplicates(fileInfo []map[string]string) []map[string]string {
 	var duplicates []map[string]string
 	const hashKey = "hash"
@@ -7,8 +11,8 @@ func Duplicates(fileInfo []map[string]string) []map[string]string {
 	for _, ref := range fileInfo {
 		for _, v := range fileInfo {
 			if ref[fileKey] != v[fileKey] && ref[hashKey] == v[hashKey] {
-				if mapArrayContains(duplicates, fileKey, v[fileKey]) ||
-					mapArrayContains(duplicates, hashKey, v[hashKey]) {
+				if list.MapArrayContains(duplicates, fileKey, v[fileKey]) ||
+					list.MapArrayContains(duplicates, hashKey, v[hashKey]) {
 					continue
 				}
 				m := map[string]string{}
@@ -22,14 +26,4 @@ func Duplicates(fileInfo []map[string]string) []map[string]string {
 		}
 	}
 	return duplicates
-}
-
-//配列の中に特定の文字列が含まれるかを返す
-func mapArrayContains(maps []map[string]string, key, str string) bool {
-	for _, v := range maps {
-		if v[key] == str {
-			return true
-		}
-	}
-	return false
 }

--- a/evaluate/duplicates.go
+++ b/evaluate/duplicates.go
@@ -1,6 +1,8 @@
 package evaluate
 
 import (
+	"sort"
+
 	"github.com/teapod89/puffer/util/list"
 )
 
@@ -15,10 +17,15 @@ func Duplicates(fileInfo []map[string]string) []map[string]string {
 					list.MapArrayContains(duplicates, hashKey, v[hashKey]) {
 					continue
 				}
+
+				//本来はfilename keyでソートすべきだが、ハッシュは同一で重複ファイルとみなすことができるためワークアラウンドとして本対応を行う。
+				var sorted []string = []string{ref[fileKey], v[fileKey]}
+				sort.Strings(sorted)
+
 				m := map[string]string{}
-				m[fileKey] = v[fileKey]
+				m[fileKey] = sorted[1]
 				m[hashKey] = v[hashKey]
-				m["duplicate_filename"] = ref[fileKey]
+				m["duplicate_filename"] = sorted[0]
 				m["duplicate_hash"] = ref[hashKey]
 				duplicates = append(duplicates, m)
 				continue

--- a/fileinfo/fileinfo.go
+++ b/fileinfo/fileinfo.go
@@ -1,0 +1,28 @@
+package fileinfo
+
+import (
+	"sync"
+
+	"github.com/teapod89/puffer/util/file"
+)
+
+func GetDirFiles(files []map[string]string) []map[string]string {
+	var wg = &sync.WaitGroup{}
+
+	var dirfiles []map[string]string
+	for i := 0; i < len(files); i++ {
+		wg.Add(1)
+		go func(i int) {
+			m := make(map[string]string)
+			d, f := file.GetFilePaths(files[i]["filename"])
+			m["directory"] = d
+			m["filename"] = f
+			m["hash"] = files[i]["hash"]
+			dirfiles = append(dirfiles, m)
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	return dirfiles
+}

--- a/main.go
+++ b/main.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 
 	"github.com/teapod89/puffer/evaluate"
-	"github.com/teapod89/puffer/files"
+	"github.com/teapod89/puffer/fileinfo"
 	"github.com/teapod89/puffer/hash"
 	"github.com/teapod89/puffer/report"
+	"github.com/teapod89/puffer/util/file"
 )
 
 func main() {
@@ -28,13 +29,15 @@ func main() {
 		log.Fatalln("Please output the target file path.")
 	}
 
-	files, err := files.Glob(*in)
+	files, err := file.Glob(*in)
 
 	if err != nil {
 		log.Println("failed to get file error.")
 	}
-	var fileInfos = hash.Calculate(files, *out, *num)
-	var duplicates = evaluate.Duplicates(fileInfos)
-	report.Out(*out, duplicates)
 
+	var fileInfos = hash.Calculate(files, *out, *num)
+
+	var duplicates = evaluate.Duplicates(fileinfo.GetDirFiles(fileInfos))
+
+	report.Out(*out, duplicates)
 }

--- a/util/file/glob.go
+++ b/util/file/glob.go
@@ -1,4 +1,4 @@
-package files
+package file
 
 import (
 	"os"

--- a/util/file/paths.go
+++ b/util/file/paths.go
@@ -1,0 +1,10 @@
+package file
+
+import (
+	"path/filepath"
+)
+
+func GetFilePaths(p string) (string, string) {
+	d, f := filepath.Split(filepath.Clean(p))
+	return d, f
+}

--- a/util/list/contains.go
+++ b/util/list/contains.go
@@ -1,0 +1,11 @@
+package list
+
+//配列の中に特定の文字列が含まれるかを返す
+func MapArrayContains(maps []map[string]string, key, str string) bool {
+	for _, v := range maps {
+		if v[key] == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Purpose
- Change the file name in the report from full path to file name only.

# Approach
- Changed the specification to pass in a hash array of path name, file name and hash when checking for duplicates.
- Packaging of some processes.
