### PR TITLE
Add the workaround to include a directory name to report.

### DIFF
--- a/evaluate/duplicates.go
+++ b/evaluate/duplicates.go
@@ -10,6 +10,7 @@ func Duplicates(fileInfo []map[string]string) ([]map[string]string, int, int) {
 	var duplicates []map[string]string
 	const hashKey = "hash"
 	const fileKey = "filename"
+	const directoryKey = "directory"
 	var fnCount, dFnCount int
 
 	for _, ref := range fileInfo {
@@ -33,9 +34,19 @@ func Duplicates(fileInfo []map[string]string) ([]map[string]string, int, int) {
 				}
 
 				m := map[string]string{}
-				m[fileKey] = fn
+
+				//階層形式のディレクトリが指定されている場合のワークアラウンド。
+				//ディレクトリ名が不一致の場合は、ソートしたファイル名を使用しない。
+				if ref[directoryKey] == v[directoryKey] {
+					m[fileKey] = fn
+					m["duplicate_filename"] = dFn
+				} else {
+					m[fileKey] = ref[fileKey]
+					m["duplicate_filename"] = v[fileKey]
+				}
+				m[directoryKey] = ref[directoryKey]
+				m["duplicate_directory"] = v[directoryKey]
 				m[hashKey] = v[hashKey]
-				m["duplicate_filename"] = dFn
 				m["duplicate_hash"] = ref[hashKey]
 				duplicates = append(duplicates, m)
 				continue

--- a/report/out.go
+++ b/report/out.go
@@ -44,6 +44,9 @@ func Out(f string, infos []map[string]string, fnCount, dFnCount int) error {
 		fh.SetCellValue("Sheet1", "C"+axisIndex, info["hash"])
 		fh.SetCellValue("Sheet1", "D"+axisIndex, info["duplicate_filename"])
 		fh.SetCellValue("Sheet1", "E"+axisIndex, info["duplicate_hash"])
+		fh.AddComment("Sheet1", "B"+axisIndex, `{"author":"system: ","text":"dir:`+info["directory"]+`"}`)
+		fh.AddComment("Sheet1", "D"+axisIndex, `{"author":"system: ","text":"dir:`+info["duplicate_directory"]+`"}`)
+
 	}
 	fh.SetCellStyle("Sheet1", "A"+strconv.Itoa(offset), "E"+strconv.Itoa(len(infos)+2), makeBodyStyle(fh))
 


### PR DESCRIPTION
# Purpose
- Add directory path information to the report.

# Approach
- Added processing of whether the directory path is the same when checking the same file as the workaround.
- Added support for outputting path names in comments (workaround).
